### PR TITLE
Usage of Maps and Arrays

### DIFF
--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -13,6 +13,7 @@ spec:
       imagePullPolicy: string  | default="IfNotPresent"
 
       command: "[]string"
+      args: "[]string"
 
       # Env
       envConfigMapName: string | default="env-configmap"
@@ -152,15 +153,7 @@ spec:
                     capabilities:
                       drop: ["ALL"]
                   command: ${schema.spec.command}
-                  args:
-                    - --port=${schema.spec.httpPort}
-                    - --cert-path=/data/cert
-                    - --port-metrics=${schema.spec.metricsPort}
-                    - --grpc-port=${schema.spec.grpcPort}
-                    - --grpc-service-name=podinfo
-                    - --level=info
-                    - --random-delay=false
-                    - --random-error=false
+                  args: ${schema.spec.args}
                   envFrom:
                     - configMapRef:
                         name: ${schema.spec.envConfigMapName}

--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -9,7 +9,7 @@ spec:
     spec:
       name:            string  | required=true
       replicas:        integer | default=2 minimum=1 maximum=50
-      image:           string
+      image:           string  | required=true
       imagePullPolicy: string  | default="IfNotPresent"
 
       command: "[]string"

--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -12,6 +12,8 @@ spec:
       image:           string
       imagePullPolicy: string  | default="IfNotPresent"
 
+      command: "[]string"
+
       # Env
       envConfigMapName: string | default="env-configmap"
 
@@ -149,7 +151,7 @@ spec:
                     readOnlyRootFilesystem:   ${schema.spec.readOnlyRootFilesystem}
                     capabilities:
                       drop: ["ALL"]
-                  command: ["./podinfo"]
+                  command: ${schema.spec.command}
                   args:
                     - --port=${schema.spec.httpPort}
                     - --cert-path=/data/cert

--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -8,7 +8,6 @@ spec:
     kind: Workload
     spec:
       name:            string  | required=true
-      namespace:       string  | default="test"
       replicas:        integer | default=2 minimum=1 maximum=50
       image:           string
       imagePullPolicy: string  | default="IfNotPresent"
@@ -62,24 +61,12 @@ spec:
 
   resources:
 
-    - id: appNamespace
-      template:
-        apiVersion: v1
-        kind: Namespace
-        metadata:
-          name: ${schema.spec.namespace}
-          # labels:
-          #   pod-security.kubernetes.io/enforce: "restricted"
-          #   pod-security.kubernetes.io/audit:    "baseline"
-          #   pod-security.kubernetes.io/warn:     "baseline"
-
     - id: serviceAccount
       template:
         apiVersion: v1
         kind: ServiceAccount
         metadata:
           name: ${schema.spec.name}-sa
-          namespace: ${appNamespace.metadata.name}
         automountServiceAccountToken: ${schema.spec.automountSAToken}
 
     # Create Role if enableRbac is true
@@ -91,7 +78,6 @@ spec:
         kind: Role
         metadata:
           name: ${schema.spec.name}-role
-          namespace: ${appNamespace.metadata.name}
         rules:
           - apiGroups: [""]
             resources: ["pods", "services"]
@@ -108,11 +94,9 @@ spec:
         kind: RoleBinding
         metadata:
           name: ${schema.spec.name}-rb
-          namespace: ${appNamespace.metadata.name}
         subjects:
           - kind: ServiceAccount
             name: ${serviceAccount.metadata.name}
-            namespace: ${appNamespace.metadata.name}
         roleRef:
           apiGroup: rbac.authorization.k8s.io
           kind: Role
@@ -124,7 +108,6 @@ spec:
         kind: Deployment
         metadata:
           name:      ${schema.spec.name}
-          namespace: ${appNamespace.metadata.name}
           labels:
             app.kubernetes.io/name: ${schema.spec.name}
         spec:
@@ -222,7 +205,6 @@ spec:
         kind: Service
         metadata:
           name:      ${schema.spec.name}
-          namespace: ${appNamespace.metadata.name}
           labels:
             app.kubernetes.io/name: ${schema.spec.name}
         spec:
@@ -247,7 +229,6 @@ spec:
         kind: HorizontalPodAutoscaler
         metadata:
           name: ${schema.spec.name}
-          namespace: ${appNamespace.metadata.name}
         spec:
           scaleTargetRef:
             apiVersion: apps/v1
@@ -277,7 +258,6 @@ spec:
         kind: NetworkPolicy
         metadata:
           name: ${schema.spec.name}-default-deny-ingress
-          namespace: ${appNamespace.metadata.name}
         spec:
           podSelector:
             matchLabels:
@@ -300,7 +280,6 @@ spec:
         kind: PodDisruptionBudget
         metadata:
           name: ${schema.spec.name}
-          namespace: ${appNamespace.metadata.name}
         spec:
           selector:
             matchLabels:
@@ -315,7 +294,6 @@ spec:
         kind: HTTPRoute
         metadata:
           name:      ${schema.spec.name}
-          namespace: ${appNamespace.metadata.name}
         spec:
           hostnames:
             - ${schema.spec.hostname}

--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -15,14 +15,12 @@ spec:
       command: "[]string"
       args: "[]string"
 
-      # Env
-      envConfigMapName: string | default="env-configmap"
+      env: "[]envVar"
 
-      ports: "[]port | required=true"
+      ports: "[]port"
 
       # Ports (scalars) --> we'll find another way later
       httpPort:        integer | default=9898 minimum=1 maximum=65535
-      metricsPort:     integer | default=9797 minimum=1 maximum=65535
       grpcPort:        integer | default=9999 minimum=1 maximum=65535
 
       # Optional HTTPRoute (boolean + strings)
@@ -63,6 +61,9 @@ spec:
         name: string
         protocol: string
         containerPort: integer | required
+      envVar:
+        name: string
+        value: string
     
     status:
       deploymentConditions: ${deployment.status.conditions}
@@ -162,9 +163,7 @@ spec:
                       drop: ["ALL"]
                   command: ${schema.spec.command}
                   args: ${schema.spec.args}
-                  envFrom:
-                    - configMapRef:
-                        name: ${schema.spec.envConfigMapName}
+                  env: ${schema.spec.env}
                   ports: ${schema.spec.ports}
                   resources:
                     requests:

--- a/kro/kro-rgd-podinfo.yaml
+++ b/kro/kro-rgd-podinfo.yaml
@@ -18,6 +18,8 @@ spec:
       # Env
       envConfigMapName: string | default="env-configmap"
 
+      ports: "[]port | required=true"
+
       # Ports (scalars) --> we'll find another way later
       httpPort:        integer | default=9898 minimum=1 maximum=65535
       metricsPort:     integer | default=9797 minimum=1 maximum=65535
@@ -56,6 +58,12 @@ spec:
 
       enableRbac:                 boolean | default=true
 
+    types:
+      port:
+        name: string
+        protocol: string
+        containerPort: integer | required
+    
     status:
       deploymentConditions: ${deployment.status.conditions}
       availableReplicas:    ${deployment.status.availableReplicas}
@@ -157,16 +165,7 @@ spec:
                   envFrom:
                     - configMapRef:
                         name: ${schema.spec.envConfigMapName}
-                  ports:
-                    - name: http
-                      containerPort: ${schema.spec.httpPort}
-                      protocol: TCP
-                    - name: http-metrics
-                      containerPort: ${schema.spec.metricsPort}
-                      protocol: TCP
-                    - name: grpc
-                      containerPort: ${schema.spec.grpcPort}
-                      protocol: TCP
+                  ports: ${schema.spec.ports}
                   resources:
                     requests:
                       cpu:    ${schema.spec.cpuRequest}

--- a/podinfo/kro-cr-podinfo.yaml
+++ b/podinfo/kro-cr-podinfo.yaml
@@ -17,5 +17,8 @@ spec:
   image:      ghcr.io/stefanprodan/podinfo:6.9.2
   envConfigMapName: podinfo-env
 
+  command:
+    - "./podinfo"
+
   # Keep HTTPRoute off for now
   createHTTPRoute: false

--- a/podinfo/kro-cr-podinfo.yaml
+++ b/podinfo/kro-cr-podinfo.yaml
@@ -2,7 +2,7 @@ apiVersion: v1
 kind: ConfigMap
 metadata:
   name: podinfo-env
-  namespace: default
+  namespace: test
 data:
   PODINFO_UI_COLOR: "#34577c"
   PODINFO_UI_MESSAGE: ""
@@ -11,10 +11,9 @@ apiVersion: kro.run/v1alpha1
 kind: Workload
 metadata:
   name: podinfo-app
-  namespace: default
+  namespace: test
 spec:
   name:       podinfo-app-kro
-  namespace:  podinfo-app-kro
   image:      ghcr.io/stefanprodan/podinfo:6.9.2
   envConfigMapName: podinfo-env
 

--- a/podinfo/kro-cr-podinfo.yaml
+++ b/podinfo/kro-cr-podinfo.yaml
@@ -18,7 +18,17 @@ spec:
   envConfigMapName: podinfo-env
 
   command:
-    - "./podinfo"
+    - ./podinfo
+
+  args:
+    - --port=9898
+    - --cert-path=/data/cert
+    - --port-metrics=9797
+    - --grpc-port=9999
+    - --grpc-service-name=podinfo
+    - --level=info
+    - --random-delay=false
+    - --random-error=false
 
   # Keep HTTPRoute off for now
   createHTTPRoute: false

--- a/podinfo/kro-cr-podinfo.yaml
+++ b/podinfo/kro-cr-podinfo.yaml
@@ -13,13 +13,11 @@ metadata:
   name: podinfo-app
   namespace: test
 spec:
-  name:       podinfo-app-kro
-  image:      ghcr.io/stefanprodan/podinfo:6.9.2
+  name: podinfo-app-kro
+  image: ghcr.io/stefanprodan/podinfo:6.9.2
   envConfigMapName: podinfo-env
-
   command:
     - ./podinfo
-
   args:
     - --port=9898
     - --cert-path=/data/cert
@@ -29,6 +27,14 @@ spec:
     - --level=info
     - --random-delay=false
     - --random-error=false
-
-  # Keep HTTPRoute off for now
+  ports:
+    - name: http
+      containerPort: 9898
+      protocol: TCP
+    - name: http-metrics
+      containerPort: 9797
+      protocol: TCP
+    - name: grpc
+      containerPort: 9999
+      protocol: TCP
   createHTTPRoute: false

--- a/podinfo/kro-cr-podinfo.yaml
+++ b/podinfo/kro-cr-podinfo.yaml
@@ -1,12 +1,3 @@
-apiVersion: v1
-kind: ConfigMap
-metadata:
-  name: podinfo-env
-  namespace: test
-data:
-  PODINFO_UI_COLOR: "#34577c"
-  PODINFO_UI_MESSAGE: ""
----
 apiVersion: kro.run/v1alpha1
 kind: Workload
 metadata:
@@ -15,7 +6,6 @@ metadata:
 spec:
   name: podinfo-app-kro
   image: ghcr.io/stefanprodan/podinfo:6.9.2
-  envConfigMapName: podinfo-env
   command:
     - ./podinfo
   args:
@@ -27,6 +17,11 @@ spec:
     - --level=info
     - --random-delay=false
     - --random-error=false
+  env:
+    - name: PODINFO_UI_COLOR
+      value: "#34577c"
+    - name: PODINFO_UI_MESSAGE
+      value: ""
   ports:
     - name: http
       containerPort: 9898


### PR DESCRIPTION
Woot! Woot! We can use `maps` and `arrays` with Kro, just found this resource: https://github.com/kubernetes-sigs/kro/blob/main/website/docs/docs/concepts/10-simple-schema.md.

- [x] Use `[]string` for `command`
- [x] Use `[]string` for `args`
- [x] Use `[]envVar` for `env`
- [x] Use `[]port` for `ports`

Additional updates, but nothing directly related:
- [x] `spec.image` required
- [x] Remove the management/creation of the `Namespace` to avoid any chicken and eggs problem, happy to chat more about that but here are some considerations why:
  - When doing `k apply -f podinfo/`, got an error that the `Namespace` doesn't exist. 
  - We could have landed where the `workload` is applied in 1 `Namespace` while the RGD could create the other resource in another `Namespace`. It would be ideal to have everything in the same `Namespace`
  - If I want to apply multiple `Workload`, each was supposed to create a `Namespace`, but what if I wanted to have these `Workloads` in the same `Namespace`
  - We could let outside of RGD ways to create the namespace: Argo Application, `kubectl create ns`, etc.