### PR TITLE
Update setup-kind-cluster.sh - Kro 0.5.0

### DIFF
--- a/scripts/setup-kind-cluster.sh
+++ b/scripts/setup-kind-cluster.sh
@@ -43,7 +43,7 @@ EOF
 # --- Install kro v0.5.0 (pinned version) ---
 KRO_VERSION="0.5.0"
 
-helm install kro oci://ghcr.io/kro-run/kro/kro \
+helm install kro oci://registry.k8s.io/kro/charts/kro \
   --namespace kro \
   --create-namespace \
   --version "${KRO_VERSION}"


### PR DESCRIPTION
Let's see if CI is successfully passing with this brand new Kro release 0.5.0: https://github.com/kubernetes-sigs/kro/releases/tag/v0.5.0